### PR TITLE
Add compatibility with SageMaker SDK v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ From a "System Terminal" in SageMaker Studio
 ```bash
 export DEV_S3_PATH_PREFIX=s3://path/to/location
 aws s3 sync ${DEV_S3_PATH_PREFIX}/sagemaker-docker-build/dist . 
-pip install sagemaker-docker-build-x.y.tar.gz
+pip install sagemaker_studio_image_build-x.y.z.tar.gz
 ```
 
 ## Security

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,11 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-required_packages = ["boto3>=1.10.44, < 2.0", "sagemaker < 2.0"]
+required_packages = ["boto3>=1.10.44, < 2.0", "sagemaker < 3.0"]
 
 setuptools.setup(
     name="sagemaker_studio_image_build",
-    version="0.3.1",
+    version="0.4.0",
     author="Amazon Web Services",
     description="Build Docker Images in Amazon SageMaker Studio using AWS CodeBuild",
     long_description=long_description,
@@ -20,7 +20,6 @@ setuptools.setup(
         "Intended Audience :: Science/Research",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],


### PR DESCRIPTION
The functionality being used from the SDK is also available in SDKv2,
    i.e., `sagemaker.session` so this code is compatible with SDKv2. As
    such relaxing the range in the dependencies to include both v1 and
    v2.

Also bumped version to 0.4 to do a release on PyPI.

Tested by building Docker image in SageMaker Studio from the examples

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
