### PR TITLE
Login to all registries with DL containers

### DIFF
--- a/sagemaker_studio_image_build/data/buildspec.template.yml
+++ b/sagemaker_studio_image_build/data/buildspec.template.yml
@@ -5,6 +5,9 @@ phases:
     commands:
       - echo Logging in to Amazon ECR...
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+      - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 763104351884)
+      - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 217643126080)
+      - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 727897471807)
   build:
     commands:
       - echo Build started on `date`


### PR DESCRIPTION
*Description of changes:*

By default, authenticate into the Deep Learning Container registries so these can be used as base images


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
