### PR TITLE
Add registry ID for af-south-1

### DIFF
--- a/sagemaker_studio_image_build/data/buildspec.template.yml
+++ b/sagemaker_studio_image_build/data/buildspec.template.yml
@@ -8,6 +8,7 @@ phases:
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 763104351884)
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 217643126080)
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 727897471807)
+      - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 626614931356)
   build:
     commands:
       - echo Build started on `date`


### PR DESCRIPTION
*Description of changes:*

Following up from https://github.com/aws-samples/sagemaker-studio-image-build-cli/pull/6 to add the registry ID for af-south-1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
