### PR TITLE
Add compute type argument

### DIFF
--- a/sagemaker_studio_image_build/builder.py
+++ b/sagemaker_studio_image_build/builder.py
@@ -64,12 +64,12 @@ def delete_zip_file(bucket, key):
     s3.delete_object(Bucket=bucket, Key=key)
 
 
-def build_image(repository, role, bucket, extra_args, log=True):
+def build_image(repository, role, bucket, compute_type, extra_args, log=True):
     bucket, key = upload_zip_file(repository, bucket, " ".join(extra_args))
     try:
         from sagemaker_studio_image_build.codebuild import TempCodeBuildProject
 
-        with TempCodeBuildProject(f"{bucket}/{key}", role, repository=repository) as p:
+        with TempCodeBuildProject(f"{bucket}/{key}", role, repository=repository, compute_type=compute_type) as p:
             p.build(log)
     finally:
         delete_zip_file(bucket, key)

--- a/sagemaker_studio_image_build/cli.py
+++ b/sagemaker_studio_image_build/cli.py
@@ -25,6 +25,14 @@ def validate_args(args, extra_args):
                     f"The value of the -f/file argument [{file_value}] is outside the working directory [{os.getcwd()}]"
                 )
 
+    # Validate arg compute_type
+    if args.compute_type:
+        if not args.compute_type in ['BUILD_GENERAL1_SMALL', 'BUILD_GENERAL1_MEDIUM',
+        'BUILD_GENERAL1_LARGE', 'BUILD_GENERAL1_LARGE', 'BUILD_GENERAL1_LARGE', 'BUILD_GENERAL1_2XLARGE']:
+            raise ValueError(
+                f'Error parsing reference: "{args.repository}" is not a valid repository/tag'
+            )
+
 
 def get_role(args):
     if args.role:
@@ -50,7 +58,7 @@ def build_image(args, extra_args):
     validate_args(args, extra_args)
 
     builder.build_image(
-        args.repository, get_role(args), args.bucket, extra_args, log=not args.no_logs
+        args.repository, get_role(args), args.bucket, args.compute_type, extra_args, log=not args.no_logs
     )
 
 
@@ -69,6 +77,15 @@ def main():
     build_parser.add_argument(
         "--repository",
         help="The ECR repository:tag for the image (default: sagemaker-studio-${domain_id}:latest)",
+    )
+    build_parser.add_argument(
+        "--image",
+        help="The ECR repository:tag for the image (default: sagemaker-studio-${domain_id}:latest)",
+    )
+    build_parser.add_argument(
+        "--compute-type",
+        help="The code build compute type (default: BUILD_GENERAL1_SMALL)",
+        default="BUILD_GENERAL1_SMALL"
     )
     build_parser.add_argument(
         "--role",

--- a/sagemaker_studio_image_build/cli.py
+++ b/sagemaker_studio_image_build/cli.py
@@ -25,14 +25,6 @@ def validate_args(args, extra_args):
                     f"The value of the -f/file argument [{file_value}] is outside the working directory [{os.getcwd()}]"
                 )
 
-    # Validate arg compute_type
-    if args.compute_type:
-        if not args.compute_type in ['BUILD_GENERAL1_SMALL', 'BUILD_GENERAL1_MEDIUM',
-        'BUILD_GENERAL1_LARGE', 'BUILD_GENERAL1_LARGE', 'BUILD_GENERAL1_LARGE', 'BUILD_GENERAL1_2XLARGE']:
-            raise ValueError(
-                f'Error parsing reference: "{args.repository}" is not a valid repository/tag'
-            )
-
 
 def get_role(args):
     if args.role:
@@ -79,12 +71,10 @@ def main():
         help="The ECR repository:tag for the image (default: sagemaker-studio-${domain_id}:latest)",
     )
     build_parser.add_argument(
-        "--image",
-        help="The ECR repository:tag for the image (default: sagemaker-studio-${domain_id}:latest)",
-    )
-    build_parser.add_argument(
         "--compute-type",
-        help="The code build compute type (default: BUILD_GENERAL1_SMALL)",
+        help="The CodeBuild compute type (default: BUILD_GENERAL1_SMALL)",
+        choices=["BUILD_GENERAL1_SMALL", "BUILD_GENERAL1_MEDIUM",
+                 "BUILD_GENERAL1_LARGE", "BUILD_GENERAL1_2XLARGE"]
         default="BUILD_GENERAL1_SMALL"
     )
     build_parser.add_argument(

--- a/sagemaker_studio_image_build/codebuild.py
+++ b/sagemaker_studio_image_build/codebuild.py
@@ -18,7 +18,7 @@ class TempCodeBuildProject:
         self.session = boto3.session.Session()
         self.domain_id, self.user_profile_name = self._get_studio_metadata()
         self.repo_name = None
-        self.compute_type = compute_type or 'BUILD_GENERAL1_SMALL'
+        self.compute_type = compute_type or "BUILD_GENERAL1_SMALL"
 
         if repository:
             self.repo_name, self.tag = repository.split(":", maxsplit=1)

--- a/sagemaker_studio_image_build/codebuild.py
+++ b/sagemaker_studio_image_build/codebuild.py
@@ -11,13 +11,14 @@ from sagemaker_studio_image_build.logs import logs_for_build
 
 
 class TempCodeBuildProject:
-    def __init__(self, s3_location, role, repository=None):
+    def __init__(self, s3_location, role, repository=None, compute_type=None):
         self.s3_location = s3_location
         self.role = role
 
         self.session = boto3.session.Session()
         self.domain_id, self.user_profile_name = self._get_studio_metadata()
         self.repo_name = None
+        self.compute_type = compute_type or 'BUILD_GENERAL1_SMALL'
 
         if repository:
             self.repo_name, self.tag = repository.split(":", maxsplit=1)
@@ -62,7 +63,7 @@ class TempCodeBuildProject:
             "environment": {
                 "type": "LINUX_CONTAINER",
                 "image": "aws/codebuild/standard:4.0",
-                "computeType": "BUILD_GENERAL1_SMALL",
+                "computeType": self.compute_type,
                 "environmentVariables": [
                     {"name": "AWS_DEFAULT_REGION", "value": region},
                     {"name": "AWS_ACCOUNT_ID", "value": account},


### PR DESCRIPTION
*Issue #, if available:* #5 

*Description of changes:*

Add `--compute-type` argument to allow specifying the [compute type](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html) down to the AWS CodeBuild job.

Compute type | computeType value | Memory | vCPUs | Disk space | Environment type
-- | -- | -- | -- | -- | --
build.general1.small | BUILD_GENERAL1_SMALL | 3 GB | 2 | 64 GB | LINUX_CONTAINER
build.general1.medium | BUILD_GENERAL1_MEDIUM | 7 GB | 4 | 128 GB | LINUX_CONTAINER
build.general1.large | BUILD_GENERAL1_LARGE | 15 GB | 8 | 128 GB | LINUX_CONTAINER
build.general1.large | BUILD_GENERAL1_LARGE | 255 GB | 32 | 50 GB | LINUX_GPU_CONTAINER
build.general1.large | BUILD_GENERAL1_LARGE | 16 GB | 8 | 50 GB | ARM_CONTAINER
build.general1.2xlarge | BUILD_GENERAL1_2XLARGE | 145 GB | 72 | 824 GB (SSD) | LINUX_CONTAINER


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
