### PR TITLE
Added eu-west-1 registry

### DIFF
--- a/sagemaker_studio_image_build/data/buildspec.template.yml
+++ b/sagemaker_studio_image_build/data/buildspec.template.yml
@@ -9,6 +9,7 @@ phases:
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 217643126080)
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 727897471807)
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 626614931356)
+      - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 141502667606)
   build:
     commands:
       - echo Build started on `date`


### PR DESCRIPTION
Added the eu-west-1 ECR registry so it's possible to run sm-docker with eu-west-1 as AWS_DEFAULT_REGION

*Issue #, if available:*

*Description of changes:*
Added the eu-west-1 registry for sagemaker studio images so it's possible to use sm-docker in ireland region

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
