### PR TITLE
Add image scanning on push to ECR repositories

### DIFF
--- a/sagemaker_studio_image_build/codebuild.py
+++ b/sagemaker_studio_image_build/codebuild.py
@@ -118,7 +118,10 @@ class TempCodeBuildProject:
     def _create_repo_if_required(self):
         client = self.session.client("ecr")
         try:
-            client.create_repository(repositoryName=self.repo_name)
+            client.create_repository(
+                repositoryName=self.repo_name,
+                imageScanningConfiguration={"scanOnPush": True},
+            )
             print(f"Created ECR repository {self.repo_name}")
         except client.exceptions.RepositoryAlreadyExistsException as e:
             pass


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Can we modify the container repositories created by CodeBuild to enable ScanOnPush by default? This seems like a best practice that we would want to lean towards for abstracted use cases like this. Plus, it's free!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
